### PR TITLE
[9주차 과제] 책임 분리를 통한 애플리케이션 설계 - STEP_17_18

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,10 +40,14 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation 'io.rest-assured:rest-assured'
-    testImplementation 'org.springframework.kafka:spring-kafka-test'
+    testImplementation 'org.testcontainers:testcontainers'
+    testImplementation 'org.testcontainers:junit-jupiter'
+    testImplementation 'org.testcontainers:kafka'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.redisson:redisson-spring-boot-starter:3.33.0'
     implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'org.springframework.kafka:spring-kafka'
     implementation 'com.google.guava:guava:33.2.1-jre'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
@@ -42,6 +43,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation 'io.rest-assured:rest-assured'
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
 }
 
 tasks.named('test') {

--- a/docker/kafka/docker-compose.yml
+++ b/docker/kafka/docker-compose.yml
@@ -1,0 +1,37 @@
+version: '3.8'
+
+services:
+  zookeeper-1:
+    image: confluentinc/cp-zookeeper:latest
+    ports:
+      - "2181:2181"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_SERVER_ID: 1
+      ZOOKEEPER_SERVERS: zookeeper-1:2888:3888
+
+  kafka-1:
+    image: confluentinc/cp-kafka:latest
+    ports:
+      - "9092:9092"
+      - "29092:29092"
+    environment:
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka-1:19092,EXTERNAL://${DOCKER_HOST_IP:-127.0.0.1}:9092,DOCKER://host.docker.internal:29092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT,DOCKER:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+      KAFKA_ZOOKEEPER_CONNECT: "zookeeper-1:2181"
+      KAFKA_BROKER_ID: 1
+    depends_on:
+      - zookeeper-1
+
+  kafka-ui:
+    image: provectuslabs/kafka-ui:latest
+    container_name: kafka-ui
+    depends_on:
+      - kafka-1
+    ports:
+      - 8989:8080
+    environment:
+      - DYNAMIC_CONFIG_ENABLED=true
+      - KAFKA_CLUSTERS_0_NAME=local_kafka_cluster
+      - KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS=kafka-1:19092

--- a/docker/mysql/docker-compose.yml
+++ b/docker/mysql/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3.8'
+services:
+  local-db:
+    image: library/mysql:8.0.23
+    container_name: mysql
+    restart: always
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+      - --sql-mode=NO_AUTO_VALUE_ON_ZERO,STRICT_TRANS_TABLES,NO_ENGINE_SUBSTITUTION
+    ports:
+      - 13306:3306
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      TZ: Asia/Seoul
+    volumes:
+      - type: bind
+        source: C:/DEV/docker/mysql8 # OS에 따라 경로 설정 변경
+        target: /var/lib/mysql

--- a/docker/redis/docker-compose.yml
+++ b/docker/redis/docker-compose.yml
@@ -6,4 +6,4 @@ services:
     volumes:
       - ./data:/data
     ports:
-      - "6380:6379"
+      - "6379:6379"

--- a/src/main/java/io/hhplus/server_construction/application/outbox/facade/OutboxFacade.java
+++ b/src/main/java/io/hhplus/server_construction/application/outbox/facade/OutboxFacade.java
@@ -5,6 +5,7 @@ import io.hhplus.server_construction.domain.outbox.service.OutboxService;
 import io.hhplus.server_construction.domain.outbox.vo.OutboxStatus;
 import io.hhplus.server_construction.support.kafka.KafkaConstants;
 import io.hhplus.server_construction.support.kafka.KafkaProducer;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -18,6 +19,7 @@ public class OutboxFacade {
     private final OutboxService outboxService;
     private final KafkaProducer kafkaProducer;
 
+    @Transactional
     public void retryOutboxMessage(LocalDateTime targetDatetime) {
         List<Outbox> outboxList = outboxService.findAllByStatusTargetDatetime(OutboxStatus.INIT, targetDatetime);
 

--- a/src/main/java/io/hhplus/server_construction/application/outbox/facade/OutboxFacade.java
+++ b/src/main/java/io/hhplus/server_construction/application/outbox/facade/OutboxFacade.java
@@ -26,17 +26,17 @@ public class OutboxFacade {
         }
 
         for (Outbox outbox : outboxList) {
-            if (outbox.cnt() >= 3) {
+            if (outbox.getCnt() >= 3) {
                 outboxService.save(outbox.failed());
                 continue;
             }
 
-            String topic = switch (outbox.messageType()) {
+            String topic = switch (outbox.getMessageType()) {
                 case RESERVATION -> KafkaConstants.RESERVATION_TOPIC;
                 case PAYMENT -> KafkaConstants.PAYMENT_TOPIC;
             };
 
-            kafkaProducer.send(topic, outbox.id(), outbox.message());
+            kafkaProducer.send(topic, outbox.getId(), outbox.getMessage());
             outboxService.save(outbox.incrementCnt());
         }
     }

--- a/src/main/java/io/hhplus/server_construction/application/outbox/facade/OutboxFacade.java
+++ b/src/main/java/io/hhplus/server_construction/application/outbox/facade/OutboxFacade.java
@@ -1,0 +1,43 @@
+package io.hhplus.server_construction.application.outbox.facade;
+
+import io.hhplus.server_construction.domain.outbox.Outbox;
+import io.hhplus.server_construction.domain.outbox.service.OutboxService;
+import io.hhplus.server_construction.domain.outbox.vo.OutboxStatus;
+import io.hhplus.server_construction.support.kafka.KafkaConstants;
+import io.hhplus.server_construction.support.kafka.KafkaProducer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class OutboxFacade {
+
+    private final OutboxService outboxService;
+    private final KafkaProducer kafkaProducer;
+
+    public void retryOutboxMessage(LocalDateTime targetDatetime) {
+        List<Outbox> outboxList = outboxService.findAllByStatusTargetDatetime(OutboxStatus.INIT, targetDatetime);
+
+        if (outboxList.isEmpty()) {
+            return;
+        }
+
+        for (Outbox outbox : outboxList) {
+            if (outbox.cnt() >= 3) {
+                outboxService.save(outbox.failed());
+                continue;
+            }
+
+            String topic = switch (outbox.messageType()) {
+                case RESERVATION -> KafkaConstants.RESERVATION_TOPIC;
+                case PAYMENT -> KafkaConstants.PAYMENT_TOPIC;
+            };
+
+            kafkaProducer.send(topic, outbox.id(), outbox.message());
+            outboxService.save(outbox.incrementCnt());
+        }
+    }
+}

--- a/src/main/java/io/hhplus/server_construction/application/payment/facade/PaymentFacade.java
+++ b/src/main/java/io/hhplus/server_construction/application/payment/facade/PaymentFacade.java
@@ -43,7 +43,7 @@ public class PaymentFacade {
         reservationService.save(reservation.changeStatus(ReservationStatus.PAYMENT_COMPLETE));
 
         // 토큰 만료 처리
-        paymentEventPublisher.paymentSuccess(new PaymentSuccessEvent(token));
+        paymentEventPublisher.paymentSuccess(PaymentSuccessEvent.create(token));
 
         return PaymentResult.create(payment);
     }

--- a/src/main/java/io/hhplus/server_construction/application/reservation/facade/ReservationFacade.java
+++ b/src/main/java/io/hhplus/server_construction/application/reservation/facade/ReservationFacade.java
@@ -5,10 +5,10 @@ import io.hhplus.server_construction.application.reservation.dto.ReservationConc
 import io.hhplus.server_construction.domain.concert.ConcertSeat;
 import io.hhplus.server_construction.domain.concert.service.ConcertService;
 import io.hhplus.server_construction.domain.concert.vo.ConcertSeatStatus;
+import io.hhplus.server_construction.domain.reservation.event.ReservationInfoEvent;
 import io.hhplus.server_construction.domain.reservation.Reservation;
 import io.hhplus.server_construction.domain.reservation.ReservationItem;
 import io.hhplus.server_construction.domain.reservation.event.ReservationEventPublisher;
-import io.hhplus.server_construction.domain.reservation.event.ReservationInfoEvent;
 import io.hhplus.server_construction.domain.reservation.service.ReservationService;
 import io.hhplus.server_construction.domain.reservation.vo.ReservationStatus;
 import io.hhplus.server_construction.domain.user.User;

--- a/src/main/java/io/hhplus/server_construction/application/reservation/facade/ReservationFacade.java
+++ b/src/main/java/io/hhplus/server_construction/application/reservation/facade/ReservationFacade.java
@@ -5,10 +5,10 @@ import io.hhplus.server_construction.application.reservation.dto.ReservationConc
 import io.hhplus.server_construction.domain.concert.ConcertSeat;
 import io.hhplus.server_construction.domain.concert.service.ConcertService;
 import io.hhplus.server_construction.domain.concert.vo.ConcertSeatStatus;
-import io.hhplus.server_construction.domain.reservation.event.ReservationInfoEvent;
 import io.hhplus.server_construction.domain.reservation.Reservation;
 import io.hhplus.server_construction.domain.reservation.ReservationItem;
 import io.hhplus.server_construction.domain.reservation.event.ReservationEventPublisher;
+import io.hhplus.server_construction.domain.reservation.event.ReservationInfoEvent;
 import io.hhplus.server_construction.domain.reservation.service.ReservationService;
 import io.hhplus.server_construction.domain.reservation.vo.ReservationStatus;
 import io.hhplus.server_construction.domain.user.User;
@@ -41,7 +41,7 @@ public class ReservationFacade {
         Reservation reservation = reservationService.setConcertReservation(concertSeatList, user);
 
         // 데이터 플랫폼 전송
-        reservationEventPublisher.sendDataPlatform(new ReservationInfoEvent(reservation));
+        reservationEventPublisher.reservationSuccess(ReservationInfoEvent.create(reservation));
 
         return ReservationConcertResult.from(reservation);
     }

--- a/src/main/java/io/hhplus/server_construction/application/waiting/facade/WaitingFacade.java
+++ b/src/main/java/io/hhplus/server_construction/application/waiting/facade/WaitingFacade.java
@@ -30,4 +30,8 @@ public class WaitingFacade {
         // 대기열 진입 가능한 토큰 상태 변경
         waitingService.activeToken();
     }
+
+    public void expiredToken(String token) {
+        waitingService.expiredToken(token);
+    }
 }

--- a/src/main/java/io/hhplus/server_construction/domain/outbox/Outbox.java
+++ b/src/main/java/io/hhplus/server_construction/domain/outbox/Outbox.java
@@ -1,0 +1,58 @@
+package io.hhplus.server_construction.domain.outbox;
+
+import io.hhplus.server_construction.domain.outbox.vo.MessageType;
+import io.hhplus.server_construction.domain.outbox.vo.OutboxStatus;
+import lombok.Builder;
+
+import java.util.UUID;
+
+@Builder
+public record Outbox(
+        String id,
+        MessageType messageType,
+        String message,
+        OutboxStatus status,
+        int cnt
+) {
+
+    public static Outbox init(MessageType messageType,
+                              String message) {
+        return Outbox.builder()
+                .id(UUID.randomUUID().toString())
+                .messageType(messageType)
+                .message(message)
+                .status(OutboxStatus.INIT)
+                .cnt(0)
+                .build();
+    }
+
+    public Outbox published() {
+        return Outbox.builder()
+                .id(this.id)
+                .messageType(this.messageType)
+                .message(this.message)
+                .status(OutboxStatus.PUBLISHED)
+                .cnt(this.cnt)
+                .build();
+    }
+
+    public Outbox failed() {
+        return Outbox.builder()
+                .id(this.id)
+                .messageType(this.messageType)
+                .message(this.message)
+                .status(OutboxStatus.FAIL)
+                .cnt(this.cnt)
+                .build();
+    }
+
+    public Outbox incrementCnt() {
+        return Outbox.builder()
+                .id(this.id)
+                .messageType(this.messageType)
+                .message(this.message)
+                .status(this.status)
+                .cnt(this.cnt + 1)
+                .build();
+    }
+}

--- a/src/main/java/io/hhplus/server_construction/domain/outbox/Outbox.java
+++ b/src/main/java/io/hhplus/server_construction/domain/outbox/Outbox.java
@@ -3,17 +3,32 @@ package io.hhplus.server_construction.domain.outbox;
 import io.hhplus.server_construction.domain.outbox.vo.MessageType;
 import io.hhplus.server_construction.domain.outbox.vo.OutboxStatus;
 import lombok.Builder;
+import lombok.Getter;
 
 import java.util.UUID;
 
+@Getter
 @Builder
-public record Outbox(
-        String id,
-        MessageType messageType,
-        String message,
-        OutboxStatus status,
-        int cnt
-) {
+public final class Outbox {
+    private final String id;
+    private final MessageType messageType;
+    private final String message;
+    private OutboxStatus status;
+    private int cnt;
+
+    public Outbox(
+            String id,
+            MessageType messageType,
+            String message,
+            OutboxStatus status,
+            int cnt
+    ) {
+        this.id = id;
+        this.messageType = messageType;
+        this.message = message;
+        this.status = status;
+        this.cnt = cnt;
+    }
 
     public static Outbox init(MessageType messageType,
                               String message) {
@@ -27,32 +42,17 @@ public record Outbox(
     }
 
     public Outbox published() {
-        return Outbox.builder()
-                .id(this.id)
-                .messageType(this.messageType)
-                .message(this.message)
-                .status(OutboxStatus.PUBLISHED)
-                .cnt(this.cnt)
-                .build();
+        this.status = OutboxStatus.PUBLISHED;
+        return this;
     }
 
     public Outbox failed() {
-        return Outbox.builder()
-                .id(this.id)
-                .messageType(this.messageType)
-                .message(this.message)
-                .status(OutboxStatus.FAIL)
-                .cnt(this.cnt)
-                .build();
+        this.status = OutboxStatus.FAIL;
+        return this;
     }
 
     public Outbox incrementCnt() {
-        return Outbox.builder()
-                .id(this.id)
-                .messageType(this.messageType)
-                .message(this.message)
-                .status(this.status)
-                .cnt(this.cnt + 1)
-                .build();
+        this.cnt = this.cnt + 1;
+        return this;
     }
 }

--- a/src/main/java/io/hhplus/server_construction/domain/outbox/repository/OutboxRepository.java
+++ b/src/main/java/io/hhplus/server_construction/domain/outbox/repository/OutboxRepository.java
@@ -1,0 +1,16 @@
+package io.hhplus.server_construction.domain.outbox.repository;
+
+import io.hhplus.server_construction.domain.outbox.Outbox;
+import io.hhplus.server_construction.domain.outbox.vo.OutboxStatus;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface OutboxRepository {
+
+    Outbox save(Outbox outbox);
+
+    Outbox findById(String id);
+
+    List<Outbox> findAllByStatusTargetDatetime(OutboxStatus outboxStatus, LocalDateTime targetDatetime);
+}

--- a/src/main/java/io/hhplus/server_construction/domain/outbox/service/OutboxService.java
+++ b/src/main/java/io/hhplus/server_construction/domain/outbox/service/OutboxService.java
@@ -1,0 +1,31 @@
+package io.hhplus.server_construction.domain.outbox.service;
+
+import io.hhplus.server_construction.domain.outbox.Outbox;
+import io.hhplus.server_construction.domain.outbox.repository.OutboxRepository;
+import io.hhplus.server_construction.domain.outbox.vo.OutboxStatus;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class OutboxService {
+
+    private final OutboxRepository outboxRepository;
+
+    @Transactional
+    public Outbox save(Outbox outbox) {
+        return outboxRepository.save(outbox);
+    }
+
+    public Outbox findById(String id) {
+        return outboxRepository.findById(id);
+    }
+
+    public List<Outbox> findAllByStatusTargetDatetime(OutboxStatus outboxStatus, LocalDateTime targetDatetime) {
+        return outboxRepository.findAllByStatusTargetDatetime(outboxStatus, targetDatetime);
+    }
+}

--- a/src/main/java/io/hhplus/server_construction/domain/outbox/vo/MessageType.java
+++ b/src/main/java/io/hhplus/server_construction/domain/outbox/vo/MessageType.java
@@ -1,0 +1,26 @@
+package io.hhplus.server_construction.domain.outbox.vo;
+
+import io.hhplus.server_construction.support.enums.EnumConverter;
+import io.hhplus.server_construction.support.enums.EnumInterface;
+import jakarta.persistence.Converter;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MessageType implements EnumInterface {
+
+    RESERVATION("RESERVATION", "예약"),
+    PAYMENT("PAYMENT", "결제");
+
+    private final String code;
+    private final String codeName;
+
+    @Converter(autoApply = true)
+    public static class JpaConverter implements EnumConverter<MessageType> {
+        @Override
+        public MessageType convertToEntityAttribute(String dbData) {
+            return EnumConverter.super.convertToEntityAttribute(dbData, MessageType.class);
+        }
+    }
+}

--- a/src/main/java/io/hhplus/server_construction/domain/outbox/vo/OutboxStatus.java
+++ b/src/main/java/io/hhplus/server_construction/domain/outbox/vo/OutboxStatus.java
@@ -1,0 +1,27 @@
+package io.hhplus.server_construction.domain.outbox.vo;
+
+import io.hhplus.server_construction.support.enums.EnumConverter;
+import io.hhplus.server_construction.support.enums.EnumInterface;
+import jakarta.persistence.Converter;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OutboxStatus implements EnumInterface {
+
+    INIT("INIT", "처리전"),
+    PUBLISHED("PUBLISHED", "발행완료"),
+    FAIL("FAIL", "실패");
+
+    private final String code;
+    private final String codeName;
+
+    @Converter(autoApply = true)
+    public static class JpaConverter implements EnumConverter<OutboxStatus> {
+        @Override
+        public OutboxStatus convertToEntityAttribute(String dbData) {
+            return EnumConverter.super.convertToEntityAttribute(dbData, OutboxStatus.class);
+        }
+    }
+}

--- a/src/main/java/io/hhplus/server_construction/domain/payment/event/PaymentSuccessEvent.java
+++ b/src/main/java/io/hhplus/server_construction/domain/payment/event/PaymentSuccessEvent.java
@@ -1,6 +1,23 @@
 package io.hhplus.server_construction.domain.payment.event;
 
-public record PaymentSuccessEvent(
-        String token
-) {
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+public final class PaymentSuccessEvent {
+    private final String token;
+    private final String outboxId;
+
+    public PaymentSuccessEvent(
+            String token,
+            String outboxId
+    ) {
+        this.token = token;
+        this.outboxId = outboxId;
+    }
+
+    public static PaymentSuccessEvent create(String token) {
+        return new PaymentSuccessEvent(token, UUID.randomUUID().toString());
+    }
 }

--- a/src/main/java/io/hhplus/server_construction/domain/reservation/ReservationItem.java
+++ b/src/main/java/io/hhplus/server_construction/domain/reservation/ReservationItem.java
@@ -1,5 +1,6 @@
 package io.hhplus.server_construction.domain.reservation;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import io.hhplus.server_construction.domain.concert.ConcertSeat;
 import lombok.Getter;
 
@@ -10,6 +11,7 @@ import java.time.LocalDateTime;
 public class ReservationItem {
 
     private final Long id;
+    @JsonBackReference
     private final Reservation reservation;
     private final ConcertSeat concertSeat;
     private final BigDecimal price;

--- a/src/main/java/io/hhplus/server_construction/domain/reservation/event/ReservationEventPublisher.java
+++ b/src/main/java/io/hhplus/server_construction/domain/reservation/event/ReservationEventPublisher.java
@@ -2,5 +2,5 @@ package io.hhplus.server_construction.domain.reservation.event;
 
 public interface ReservationEventPublisher {
 
-    void sendDataPlatform(ReservationInfoEvent reservationInfoEvent);
+    void reservationSuccess(ReservationInfoEvent reservationInfoEvent);
 }

--- a/src/main/java/io/hhplus/server_construction/domain/reservation/event/ReservationInfoEvent.java
+++ b/src/main/java/io/hhplus/server_construction/domain/reservation/event/ReservationInfoEvent.java
@@ -1,8 +1,25 @@
 package io.hhplus.server_construction.domain.reservation.event;
 
 import io.hhplus.server_construction.domain.reservation.Reservation;
+import lombok.Getter;
 
-public record ReservationInfoEvent(
-        Reservation reservation
-) {
+import java.util.UUID;
+
+@Getter
+public final class ReservationInfoEvent {
+    private final Reservation reservation;
+    private final String outboxId;
+
+    public ReservationInfoEvent(
+            Reservation reservation,
+            String outboxId
+    ) {
+        this.reservation = reservation;
+        this.outboxId = outboxId;
+    }
+
+    public static ReservationInfoEvent create(Reservation reservation) {
+        return new ReservationInfoEvent(reservation, UUID.randomUUID().toString());
+    }
+
 }

--- a/src/main/java/io/hhplus/server_construction/infra/outbox/OutboxJpaRepository.java
+++ b/src/main/java/io/hhplus/server_construction/infra/outbox/OutboxJpaRepository.java
@@ -1,0 +1,14 @@
+package io.hhplus.server_construction.infra.outbox;
+
+
+import io.hhplus.server_construction.domain.outbox.vo.OutboxStatus;
+import io.hhplus.server_construction.infra.outbox.entity.OutboxEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface OutboxJpaRepository extends JpaRepository<OutboxEntity, String> {
+
+    List<OutboxEntity> findAllByStatusAndCreateDatetimeBefore(OutboxStatus status, LocalDateTime targetDatetime);
+}

--- a/src/main/java/io/hhplus/server_construction/infra/outbox/OutboxJpaRepository.java
+++ b/src/main/java/io/hhplus/server_construction/infra/outbox/OutboxJpaRepository.java
@@ -10,5 +10,5 @@ import java.util.List;
 
 public interface OutboxJpaRepository extends JpaRepository<OutboxEntity, String> {
 
-    List<OutboxEntity> findAllByStatusAndCreateDatetimeBefore(OutboxStatus status, LocalDateTime targetDatetime);
+    List<OutboxEntity> findAllByStatusAndModifyDatetimeBefore(OutboxStatus status, LocalDateTime targetDatetime);
 }

--- a/src/main/java/io/hhplus/server_construction/infra/outbox/OutboxRepositoryImpl.java
+++ b/src/main/java/io/hhplus/server_construction/infra/outbox/OutboxRepositoryImpl.java
@@ -31,7 +31,7 @@ public class OutboxRepositoryImpl implements OutboxRepository {
 
     @Override
     public List<Outbox> findAllByStatusTargetDatetime(OutboxStatus outboxStatus, LocalDateTime targetDatetime) {
-        return outboxJpaRepository.findAllByStatusAndCreateDatetimeBefore(outboxStatus, targetDatetime).stream()
+        return outboxJpaRepository.findAllByStatusAndModifyDatetimeBefore(outboxStatus, targetDatetime).stream()
                 .map(OutboxEntity::toDomain)
                 .toList();
     }

--- a/src/main/java/io/hhplus/server_construction/infra/outbox/OutboxRepositoryImpl.java
+++ b/src/main/java/io/hhplus/server_construction/infra/outbox/OutboxRepositoryImpl.java
@@ -1,0 +1,38 @@
+package io.hhplus.server_construction.infra.outbox;
+
+import io.hhplus.server_construction.domain.outbox.Outbox;
+import io.hhplus.server_construction.domain.outbox.repository.OutboxRepository;
+import io.hhplus.server_construction.domain.outbox.vo.OutboxStatus;
+import io.hhplus.server_construction.infra.outbox.entity.OutboxEntity;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+
+@Repository
+@RequiredArgsConstructor
+public class OutboxRepositoryImpl implements OutboxRepository {
+
+    private final OutboxJpaRepository outboxJpaRepository;
+
+    public Outbox save(Outbox outbox) {
+        return outboxJpaRepository.save(OutboxEntity.toEntity(outbox)).toDomain();
+    }
+
+    @Override
+    public Outbox findById(String id) {
+        return outboxJpaRepository.findById(id)
+                .orElseThrow(EntityNotFoundException::new)
+                .toDomain();
+    }
+
+    @Override
+    public List<Outbox> findAllByStatusTargetDatetime(OutboxStatus outboxStatus, LocalDateTime targetDatetime) {
+        return outboxJpaRepository.findAllByStatusAndCreateDatetimeBefore(outboxStatus, targetDatetime).stream()
+                .map(OutboxEntity::toDomain)
+                .toList();
+    }
+}

--- a/src/main/java/io/hhplus/server_construction/infra/outbox/entity/OutboxEntity.java
+++ b/src/main/java/io/hhplus/server_construction/infra/outbox/entity/OutboxEntity.java
@@ -53,10 +53,10 @@ public class OutboxEntity extends BaseEntity {
     }
 
     public static OutboxEntity toEntity(Outbox outbox) {
-        return new OutboxEntity(outbox.id(),
-                outbox.messageType(),
-                outbox.message(),
-                outbox.status(),
-                outbox.cnt());
+        return new OutboxEntity(outbox.getId(),
+                outbox.getMessageType(),
+                outbox.getMessage(),
+                outbox.getStatus(),
+                outbox.getCnt());
     }
 }

--- a/src/main/java/io/hhplus/server_construction/infra/outbox/entity/OutboxEntity.java
+++ b/src/main/java/io/hhplus/server_construction/infra/outbox/entity/OutboxEntity.java
@@ -1,0 +1,62 @@
+package io.hhplus.server_construction.infra.outbox.entity;
+
+import io.hhplus.server_construction.domain.outbox.Outbox;
+import io.hhplus.server_construction.domain.outbox.vo.MessageType;
+import io.hhplus.server_construction.domain.outbox.vo.OutboxStatus;
+import io.hhplus.server_construction.infra.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "outbox")
+public class OutboxEntity extends BaseEntity {
+
+    @Id
+    private String id;
+
+    private MessageType messageType;
+
+    @Column(columnDefinition = "longtext")
+    private String message;
+
+    private OutboxStatus status;
+
+    private int cnt;
+
+    public OutboxEntity(String id,
+                        MessageType messageType,
+                        String message,
+                        OutboxStatus status,
+                        int cnt) {
+        this.id = id;
+        this.messageType = messageType;
+        this.message = message;
+        this.status = status;
+        this.cnt = cnt;
+    }
+
+    public Outbox toDomain() {
+        return Outbox.builder()
+                .id(this.id)
+                .messageType(this.messageType)
+                .message(this.message)
+                .status(this.status)
+                .cnt(this.cnt)
+                .build();
+    }
+
+    public static OutboxEntity toEntity(Outbox outbox) {
+        return new OutboxEntity(outbox.id(),
+                outbox.messageType(),
+                outbox.message(),
+                outbox.status(),
+                outbox.cnt());
+    }
+}

--- a/src/main/java/io/hhplus/server_construction/infra/reservation/ReservationEventPublisherImpl.java
+++ b/src/main/java/io/hhplus/server_construction/infra/reservation/ReservationEventPublisherImpl.java
@@ -13,7 +13,7 @@ public class ReservationEventPublisherImpl implements ReservationEventPublisher 
     private final ApplicationEventPublisher applicationEventPublisher;
 
     @Override
-    public void sendDataPlatform(ReservationInfoEvent reservationInfoEvent) {
+    public void reservationSuccess(ReservationInfoEvent reservationInfoEvent) {
         applicationEventPublisher.publishEvent(reservationInfoEvent);
     }
 }

--- a/src/main/java/io/hhplus/server_construction/interfaces/consumer/PaymentMessageConsumer.java
+++ b/src/main/java/io/hhplus/server_construction/interfaces/consumer/PaymentMessageConsumer.java
@@ -1,0 +1,35 @@
+package io.hhplus.server_construction.interfaces.consumer;
+
+import io.hhplus.server_construction.application.waiting.facade.WaitingFacade;
+import io.hhplus.server_construction.domain.outbox.Outbox;
+import io.hhplus.server_construction.domain.outbox.service.OutboxService;
+import io.hhplus.server_construction.support.kafka.KafkaConstants;
+import io.hhplus.server_construction.support.util.JsonUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentMessageConsumer {
+
+    private final OutboxService outboxService;
+    private final WaitingFacade waitingFacade;
+
+    @KafkaListener(topics = KafkaConstants.PAYMENT_TOPIC, groupId = "payment-outbox")
+    public void checkOutbox(ConsumerRecord<String, String> record) {
+        log.info("[payment-outbox] key: {}", record.key());
+        Outbox outbox = outboxService.findById(record.key());
+        outboxService.save(outbox.published());
+    }
+
+    @KafkaListener(topics = KafkaConstants.PAYMENT_TOPIC, groupId = "payment-process")
+    public void tokenExpired(ConsumerRecord<String, String> record) {
+        log.info("[payment-process] value: {}", record.value());
+        String token = JsonUtil.stringToObject(record.value(), String.class);
+        waitingFacade.expiredToken(token);
+    }
+}

--- a/src/main/java/io/hhplus/server_construction/interfaces/consumer/ReservationMessageConsumer.java
+++ b/src/main/java/io/hhplus/server_construction/interfaces/consumer/ReservationMessageConsumer.java
@@ -22,12 +22,14 @@ public class ReservationMessageConsumer {
 
     @KafkaListener(topics = KafkaConstants.RESERVATION_TOPIC, groupId = "reservation-outbox")
     public void checkOutbox(ConsumerRecord<String, String> record) {
+        log.info("[reservation-outbox] key: {}", record.key());
         Outbox outbox = outboxService.findById(record.key());
         outboxService.save(outbox.published());
     }
 
     @KafkaListener(topics = KafkaConstants.RESERVATION_TOPIC, groupId = "reservation-process")
     public void reserved(ConsumerRecord<String, String> record) throws InterruptedException {
+        log.info("[reservation-process] value: {}", record.value());
         Reservation reservation = JsonUtil.stringToObject(record.value(), Reservation.class);
         dataPlatformFacade.sendReservationInfo(reservation);
     }

--- a/src/main/java/io/hhplus/server_construction/interfaces/consumer/ReservationMessageConsumer.java
+++ b/src/main/java/io/hhplus/server_construction/interfaces/consumer/ReservationMessageConsumer.java
@@ -1,0 +1,34 @@
+package io.hhplus.server_construction.interfaces.consumer;
+
+import io.hhplus.server_construction.application.data_platform.facade.DataPlatformFacade;
+import io.hhplus.server_construction.domain.outbox.Outbox;
+import io.hhplus.server_construction.domain.outbox.service.OutboxService;
+import io.hhplus.server_construction.domain.reservation.Reservation;
+import io.hhplus.server_construction.support.kafka.KafkaConstants;
+import io.hhplus.server_construction.support.util.JsonUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReservationMessageConsumer {
+
+    private final OutboxService outboxService;
+    private final DataPlatformFacade dataPlatformFacade;
+
+    @KafkaListener(topics = KafkaConstants.RESERVATION_TOPIC, groupId = "reservation-outbox")
+    public void checkOutbox(ConsumerRecord<String, String> record) {
+        Outbox outbox = outboxService.findById(record.key());
+        outboxService.save(outbox.published());
+    }
+
+    @KafkaListener(topics = KafkaConstants.RESERVATION_TOPIC, groupId = "reservation-process")
+    public void reserved(ConsumerRecord<String, String> record) throws InterruptedException {
+        Reservation reservation = JsonUtil.stringToObject(record.value(), Reservation.class);
+        dataPlatformFacade.sendReservationInfo(reservation);
+    }
+}

--- a/src/main/java/io/hhplus/server_construction/interfaces/event/payment/PaymentEventListener.java
+++ b/src/main/java/io/hhplus/server_construction/interfaces/event/payment/PaymentEventListener.java
@@ -1,4 +1,4 @@
-package io.hhplus.server_construction.interfaces.event.waiting;
+package io.hhplus.server_construction.interfaces.event.payment;
 
 import io.hhplus.server_construction.domain.payment.event.PaymentSuccessEvent;
 import io.hhplus.server_construction.domain.waiting.service.WaitingService;
@@ -10,7 +10,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
 @RequiredArgsConstructor
-public class TokenEventListener {
+public class PaymentEventListener {
 
     private final WaitingService waitingService;
 

--- a/src/main/java/io/hhplus/server_construction/interfaces/event/payment/PaymentEventListener.java
+++ b/src/main/java/io/hhplus/server_construction/interfaces/event/payment/PaymentEventListener.java
@@ -1,23 +1,34 @@
 package io.hhplus.server_construction.interfaces.event.payment;
 
+import io.hhplus.server_construction.domain.outbox.Outbox;
+import io.hhplus.server_construction.domain.outbox.service.OutboxService;
+import io.hhplus.server_construction.domain.outbox.vo.MessageType;
 import io.hhplus.server_construction.domain.payment.event.PaymentSuccessEvent;
-import io.hhplus.server_construction.domain.waiting.service.WaitingService;
+import io.hhplus.server_construction.support.kafka.KafkaProducer;
+import io.hhplus.server_construction.support.util.JsonUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+import static io.hhplus.server_construction.support.kafka.KafkaConstants.RESERVATION_TOPIC;
+
 @Component
 @RequiredArgsConstructor
 public class PaymentEventListener {
 
-    private final WaitingService waitingService;
+    private final OutboxService outboxService;
+    private final KafkaProducer kafkaProducer;
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void createOutbox(PaymentSuccessEvent event) {
+        outboxService.save(Outbox.init(MessageType.PAYMENT, JsonUtil.objectToString(event.getToken())));
+    }
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void tokenExpireHandler(PaymentSuccessEvent event) {
-        // 토큰 만료 처리
-        waitingService.expiredToken(event.token());
+        kafkaProducer.send(RESERVATION_TOPIC, event.getOutboxId(), event.getToken());
     }
 }

--- a/src/main/java/io/hhplus/server_construction/interfaces/event/reservation/ReservationEventListener.java
+++ b/src/main/java/io/hhplus/server_construction/interfaces/event/reservation/ReservationEventListener.java
@@ -1,4 +1,4 @@
-package io.hhplus.server_construction.interfaces.event.data_platform;
+package io.hhplus.server_construction.interfaces.event.reservation;
 
 import io.hhplus.server_construction.application.data_platform.facade.DataPlatformFacade;
 import io.hhplus.server_construction.domain.reservation.event.ReservationInfoEvent;
@@ -12,7 +12,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class DataPlatformEventListener {
+public class ReservationEventListener {
 
     private final DataPlatformFacade dataPlatformFacade;
 

--- a/src/main/java/io/hhplus/server_construction/interfaces/event/reservation/ReservationEventListener.java
+++ b/src/main/java/io/hhplus/server_construction/interfaces/event/reservation/ReservationEventListener.java
@@ -1,7 +1,11 @@
 package io.hhplus.server_construction.interfaces.event.reservation;
 
-import io.hhplus.server_construction.application.data_platform.facade.DataPlatformFacade;
+import io.hhplus.server_construction.domain.outbox.Outbox;
+import io.hhplus.server_construction.domain.outbox.service.OutboxService;
+import io.hhplus.server_construction.domain.outbox.vo.MessageType;
 import io.hhplus.server_construction.domain.reservation.event.ReservationInfoEvent;
+import io.hhplus.server_construction.support.kafka.KafkaProducer;
+import io.hhplus.server_construction.support.util.JsonUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
@@ -9,21 +13,24 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+import static io.hhplus.server_construction.support.kafka.KafkaConstants.RESERVATION_TOPIC;
+
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class ReservationEventListener {
 
-    private final DataPlatformFacade dataPlatformFacade;
+    private final OutboxService outboxService;
+    private final KafkaProducer kafkaProducer;
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void createOutbox(ReservationInfoEvent event) {
+        outboxService.save(Outbox.init(MessageType.RESERVATION, JsonUtil.objectToString(event.getReservation())));
+    }
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void reservationDataSendHandler(ReservationInfoEvent event) {
-        try {
-            // 데이터 플랫폼 전송
-            dataPlatformFacade.sendReservationInfo(event.reservation());
-        } catch (InterruptedException e) {
-            log.error("send payment info error", e);
-        }
+        kafkaProducer.send(RESERVATION_TOPIC, event.getOutboxId(), event.getReservation());
     }
 }

--- a/src/main/java/io/hhplus/server_construction/interfaces/scheduler/OutboxScheduler.java
+++ b/src/main/java/io/hhplus/server_construction/interfaces/scheduler/OutboxScheduler.java
@@ -1,0 +1,21 @@
+package io.hhplus.server_construction.interfaces.scheduler;
+
+import io.hhplus.server_construction.application.outbox.facade.OutboxFacade;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class OutboxScheduler {
+
+    private final OutboxFacade outboxFacade;
+
+    // 5분마다 실행
+    @Scheduled(cron = "0 */5 * * * *")
+    public void run() {
+        outboxFacade.retryOutboxMessage(LocalDateTime.now().minusMinutes(5));
+    }
+}

--- a/src/main/java/io/hhplus/server_construction/support/config/KafkaConsumerConfig.java
+++ b/src/main/java/io/hhplus/server_construction/support/config/KafkaConsumerConfig.java
@@ -18,7 +18,7 @@ import java.util.Map;
 @Configuration
 public class KafkaConsumerConfig {
 
-    @Value("${spring.kafka.producer.bootstrap-servers}")
+    @Value("${spring.kafka.consumer.bootstrap-servers}")
     private String bootstrapServers;
 
     @Bean
@@ -26,7 +26,8 @@ public class KafkaConsumerConfig {
         Map<String, Object> props = new HashMap<>();
         props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
         return new DefaultKafkaConsumerFactory<>(props);
     }
 

--- a/src/main/java/io/hhplus/server_construction/support/config/KafkaConsumerConfig.java
+++ b/src/main/java/io/hhplus/server_construction/support/config/KafkaConsumerConfig.java
@@ -22,7 +22,7 @@ public class KafkaConsumerConfig {
     private String bootstrapServers;
 
     @Bean
-    public ConsumerFactory<String, Object> consumerFactory() {
+    public ConsumerFactory<String, String> consumerFactory() {
         Map<String, Object> props = new HashMap<>();
         props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
@@ -31,8 +31,8 @@ public class KafkaConsumerConfig {
     }
 
     @Bean
-    public ConcurrentKafkaListenerContainerFactory<String, Object> kafkaListenerContainerFactory() {
-        ConcurrentKafkaListenerContainerFactory<String, Object> factory = new ConcurrentKafkaListenerContainerFactory<>();
+    public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(consumerFactory());
         return factory;
     }

--- a/src/main/java/io/hhplus/server_construction/support/config/KafkaConsumerConfig.java
+++ b/src/main/java/io/hhplus/server_construction/support/config/KafkaConsumerConfig.java
@@ -1,0 +1,39 @@
+package io.hhplus.server_construction.support.config;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@EnableKafka
+@Configuration
+public class KafkaConsumerConfig {
+
+    @Value("${spring.kafka.producer.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Bean
+    public ConsumerFactory<String, Object> consumerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        return new DefaultKafkaConsumerFactory<>(props);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, Object> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, Object> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        return factory;
+    }
+}

--- a/src/main/java/io/hhplus/server_construction/support/config/KafkaProducerConfig.java
+++ b/src/main/java/io/hhplus/server_construction/support/config/KafkaProducerConfig.java
@@ -8,7 +8,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
-import org.springframework.kafka.support.serializer.JsonSerializer;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -24,7 +23,7 @@ public class KafkaProducerConfig {
         Map<String, Object> props = new HashMap<>();
         props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
-        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
         return new DefaultKafkaProducerFactory<>(props);
     }
 

--- a/src/main/java/io/hhplus/server_construction/support/config/KafkaProducerConfig.java
+++ b/src/main/java/io/hhplus/server_construction/support/config/KafkaProducerConfig.java
@@ -20,7 +20,7 @@ public class KafkaProducerConfig {
     private String bootstrapServers;
 
     @Bean
-    public ProducerFactory<String, Object> factory() {
+    public ProducerFactory<String, String> factory() {
         Map<String, Object> props = new HashMap<>();
         props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
@@ -29,7 +29,7 @@ public class KafkaProducerConfig {
     }
 
     @Bean
-    public KafkaTemplate<String, Object> kafkaTemplate() {
+    public KafkaTemplate<String, String> kafkaTemplate() {
         return new KafkaTemplate<>(factory());
     }
 }

--- a/src/main/java/io/hhplus/server_construction/support/config/KafkaProducerConfig.java
+++ b/src/main/java/io/hhplus/server_construction/support/config/KafkaProducerConfig.java
@@ -1,0 +1,35 @@
+package io.hhplus.server_construction.support.config;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaProducerConfig {
+
+    @Value("${spring.kafka.producer.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Bean
+    public ProducerFactory<String, Object> factory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        return new DefaultKafkaProducerFactory<>(props);
+    }
+
+    @Bean
+    public KafkaTemplate<String, Object> kafkaTemplate() {
+        return new KafkaTemplate<>(factory());
+    }
+}

--- a/src/main/java/io/hhplus/server_construction/support/kafka/KafkaConstants.java
+++ b/src/main/java/io/hhplus/server_construction/support/kafka/KafkaConstants.java
@@ -1,0 +1,7 @@
+package io.hhplus.server_construction.support.kafka;
+
+public class KafkaConstants {
+
+    public static final String RESERVATION_TOPIC = "RESERVATION";
+    public static final String PAYMENT_TOPIC = "PAYMENT";
+}

--- a/src/main/java/io/hhplus/server_construction/support/kafka/KafkaProducer.java
+++ b/src/main/java/io/hhplus/server_construction/support/kafka/KafkaProducer.java
@@ -1,0 +1,30 @@
+package io.hhplus.server_construction.support.kafka;
+
+import io.hhplus.server_construction.support.util.JsonUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KafkaProducer {
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    public void send(String topic, String outboxId, Object message) {
+        kafkaTemplate.send(topic, outboxId, JsonUtil.objectToString(message)).whenComplete((result, throwable) -> {
+            if (throwable != null) {
+                log.error("[Produce Fail] message: {}", throwable.getMessage(), throwable);
+            } else {
+                RecordMetadata recordMetadata = result.getRecordMetadata();
+                log.info("[Produce Success] topic:{}, value: {}, offset: {}",
+                        recordMetadata.topic(),
+                        result.getProducerRecord().value(),
+                        recordMetadata.offset());
+            }
+        });
+    }
+}

--- a/src/main/java/io/hhplus/server_construction/support/util/JsonUtil.java
+++ b/src/main/java/io/hhplus/server_construction/support/util/JsonUtil.java
@@ -1,0 +1,138 @@
+package io.hhplus.server_construction.support.util;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import jodd.util.StringUtil;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+
+import java.lang.reflect.Type;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Slf4j
+public class JsonUtil {
+
+    private JsonUtil() {
+        throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
+    }
+
+    private static final String ERROR = "ERROR : ";
+
+    public static final ObjectMapper OBJECT_MAPPER = Jackson2ObjectMapperBuilder.json()
+            .serializerByType(LocalDate.class, new LocalDateSerializer(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
+            .serializerByType(LocalDateTime.class, new LocalDateTimeSerializer(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")))
+            .deserializerByType(LocalDate.class, new LocalDateTypeConvertDeserializer())
+            .deserializerByType(LocalDateTime.class, new LocalDateTimeTypeConvertDeserializer())
+            .featuresToEnable(SerializationFeature.INDENT_OUTPUT) // Pretty Printing 활성화
+            .featuresToDisable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES) // dto 에 존재 하지 않는 속성이 있는 경우 무시
+            .visibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY) // public 필드 / getter 메서드 유무 상관 없이 직렬화
+            .build();
+
+    /**
+     * Java Object => Json 직렬화된 String 반환
+     */
+    public static String objectToString(Object javaObject) {
+        String jsonString;
+        try {
+            jsonString = OBJECT_MAPPER.writeValueAsString(javaObject);
+        } catch (JsonProcessingException e) {
+            log.error(ERROR, e);
+            throw new RuntimeException(e);
+        }
+        return jsonString;
+    }
+
+    public static String objectToString(Object javaObject, boolean enablePrettyPrint) {
+        ObjectMapper mapper = enablePrettyPrint ? OBJECT_MAPPER : OBJECT_MAPPER.disable(SerializationFeature.INDENT_OUTPUT);
+        String jsonString;
+        try {
+            jsonString = mapper.writeValueAsString(javaObject);
+        } catch (JsonProcessingException e) {
+            log.error(ERROR, e);
+            throw new RuntimeException(e);
+        }
+        return jsonString;
+    }
+
+    /**
+     * String Object 로 변환
+     */
+    public static <T> T stringToObject(String request, Class<T> valueType) {
+        if (StringUtil.isEmpty(request)) return null;
+
+        T returnValue;
+        try {
+            returnValue = OBJECT_MAPPER.readValue(request, valueType);
+        } catch (JsonProcessingException e) {
+            log.error(ERROR, e);
+            throw new RuntimeException(e);
+        }
+        return returnValue;
+    }
+
+
+    /**
+     * String Object 로 변환
+     */
+    public static <T> T stringToObject(String request, TypeReference<T> valueTypeRef) {
+        if (StringUtil.isEmpty(request)) return null;
+
+        T returnValue = null;
+        try {
+            Type type = valueTypeRef.getType();
+            if (type.getTypeName().equalsIgnoreCase("org.springframework.http.ResponseEntity<java.lang.Boolean>")) {
+                if (request.equalsIgnoreCase("true")) {
+                    returnValue = (T) ResponseEntity.ok(Boolean.TRUE);
+                } else if (request.equalsIgnoreCase("false")) {
+                    returnValue = (T) ResponseEntity.ok(Boolean.FALSE);
+                }
+            } else {
+                returnValue = OBJECT_MAPPER.readValue(request, valueTypeRef);
+            }
+        } catch (JsonProcessingException e) {
+            log.error(ERROR, e);
+            throw new RuntimeException(e);
+        }
+        return returnValue;
+    }
+
+    /**
+     * String Object 로 변환
+     */
+    public static <T> T stringToObject(String request, JavaType valueType) {
+        if (StringUtil.isEmpty(request)) return null;
+
+        T returnValue;
+        try {
+            returnValue = OBJECT_MAPPER.readValue(request, valueType);
+        } catch (JsonProcessingException e) {
+            log.error(ERROR, e);
+            throw new RuntimeException(e);
+        }
+        return returnValue;
+    }
+
+    /**
+     * String JsonNode 로 변환
+     */
+    public static JsonNode stringToJsonNode(String request) {
+        if (StringUtil.isEmpty(request)) return null;
+
+        JsonNode returnJsonNode;
+        try {
+            returnJsonNode = OBJECT_MAPPER.readTree(request);
+        } catch (JsonProcessingException e) {
+            log.error(ERROR, e);
+            throw new RuntimeException(e);
+        }
+        return returnJsonNode;
+    }
+}

--- a/src/main/java/io/hhplus/server_construction/support/util/LocalDateTimeTypeConvertDeserializer.java
+++ b/src/main/java/io/hhplus/server_construction/support/util/LocalDateTimeTypeConvertDeserializer.java
@@ -1,0 +1,44 @@
+package io.hhplus.server_construction.support.util;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+/**
+ * Json => LocalDate 역직렬화
+ */
+public class LocalDateTimeTypeConvertDeserializer extends StdDeserializer<LocalDateTime> {
+    private static final DateTimeFormatter[] DATE_FORMATTERS = {
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss"),
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+    };
+
+    public LocalDateTimeTypeConvertDeserializer() {
+        super(LocalDateTime.class);
+    }
+
+    @Override
+    public LocalDateTime deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
+        String dateString = jsonParser.getValueAsString();
+
+        if (dateString == null || dateString.trim().isEmpty()) {
+            return null;
+        }
+
+        for (DateTimeFormatter formatter : DATE_FORMATTERS) {
+            try {
+                return LocalDateTime.parse(dateString, formatter);
+            } catch (DateTimeParseException e) {
+                // 다음 패턴으로 계속 시도
+            }
+        }
+
+        // 모든 패턴으로 파싱할 수 없으면 예외 던지기
+        throw new RuntimeException("to localDate error");
+    }
+}

--- a/src/main/java/io/hhplus/server_construction/support/util/LocalDateTypeConvertDeserializer.java
+++ b/src/main/java/io/hhplus/server_construction/support/util/LocalDateTypeConvertDeserializer.java
@@ -1,0 +1,44 @@
+package io.hhplus.server_construction.support.util;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+/**
+ * Json => LocalDate 역직렬화
+ */
+public class LocalDateTypeConvertDeserializer extends StdDeserializer<LocalDate> {
+
+    private static final DateTimeFormatter[] DATE_FORMATTERS = {
+            DateTimeFormatter.ofPattern("yyyyMMdd"),
+            DateTimeFormatter.ofPattern("yyyy-MM-dd")
+    };
+
+    public LocalDateTypeConvertDeserializer() {
+        super(LocalDate.class);
+    }
+
+    @Override
+    public LocalDate deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
+        String dateString = jsonParser.getValueAsString();
+        if (dateString == null || dateString.trim().isEmpty()) {
+            return null;
+        }
+
+        for (DateTimeFormatter formatter : DATE_FORMATTERS) {
+            try {
+                return LocalDate.parse(dateString, formatter);
+            } catch (DateTimeParseException e) {
+                // 다음 패턴으로 계속 시도
+            }
+        }
+
+        // 모든 패턴으로 파싱할 수 없으면 예외 던지기
+        throw new RuntimeException("to localDate error");
+    }
+}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -22,6 +22,10 @@ spring:
     username: root
     password: root
 
+  kafka:
+    producer:
+      bootstrap-servers: localhost:9092
+
 slack:
   webhook:
     url: https://hooks.slack.com/services/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

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -4,7 +4,7 @@ spring:
       on-profile: test
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: create
     show-sql: true
     properties:
       hibernate:
@@ -30,8 +30,12 @@ spring:
     password: root
 
   kafka:
+    bootstrap-servers: localhost:9092
     producer:
       bootstrap-servers: localhost:9092
+    consumer:
+      bootstrap-servers: localhost:9092
+      auto-offset-reset: earliest
 
 slack:
   webhook:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,7 +12,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
     show-sql: true
     properties:
       hibernate:
@@ -34,8 +34,12 @@ spring:
     type: redis
 
   kafka:
+    bootstrap-servers: localhost:9092
     producer:
       bootstrap-servers: localhost:9092
+    consumer:
+      bootstrap-servers: localhost:9092
+      auto-offset-reset: earliest
 
 slack:
   webhook:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,7 +4,7 @@ spring:
       on-profile: default
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: create
     show-sql: true
     properties:
       hibernate:
@@ -24,6 +24,10 @@ spring:
 
   cache:
     type: redis
+
+  kafka:
+    producer:
+      bootstrap-servers: localhost:9092
 
 slack:
   webhook:

--- a/src/test/java/io/hhplus/server_construction/application/outbox/facade/OutboxFacadeIntegratedTest.java
+++ b/src/test/java/io/hhplus/server_construction/application/outbox/facade/OutboxFacadeIntegratedTest.java
@@ -1,0 +1,63 @@
+package io.hhplus.server_construction.application.outbox.facade;
+
+import io.hhplus.server_construction.domain.outbox.Outbox;
+import io.hhplus.server_construction.domain.outbox.repository.OutboxRepository;
+import io.hhplus.server_construction.domain.outbox.vo.MessageType;
+import io.hhplus.server_construction.domain.outbox.vo.OutboxStatus;
+import io.hhplus.server_construction.support.testcontainer.KafkaTestContainer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class OutboxFacadeIntegratedTest implements KafkaTestContainer {
+
+    @Autowired
+    OutboxFacade outboxFacade;
+
+    @Autowired
+    OutboxRepository outboxRepository;
+
+    @Test
+    @DisplayName("5분 지난 초기 상태 Outbox 를 Kafka 재발행 한다.")
+    void reissueOutbox() {
+        // given
+        Outbox outbox = new Outbox("TEST", MessageType.RESERVATION, "TEST", OutboxStatus.INIT, 0);
+        outboxRepository.save(outbox);
+
+        // when
+        outboxFacade.retryOutboxMessage(LocalDateTime.now().plusMinutes(10));
+
+        // then
+        Outbox result = outboxRepository.findById(outbox.getId());
+        await().pollDelay(2, TimeUnit.SECONDS)
+                .atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(outboxRepository.findById(outbox.getId()).getStatus()).isEqualTo(OutboxStatus.PUBLISHED));
+
+        assertThat(result.getCnt()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("재시도 회수 3회 이상 Outbox 실패 처리")
+    void retriesMoreThan3() {
+        // given
+        Outbox outbox = new Outbox("TEST", MessageType.RESERVATION, "TEST", OutboxStatus.INIT, 3);
+        outboxRepository.save(outbox);
+
+        // when
+        outboxFacade.retryOutboxMessage(LocalDateTime.now().plusMinutes(10));
+
+        // then
+        Outbox result = outboxRepository.findById(outbox.getId());
+        assertThat(result.getStatus()).isEqualTo(OutboxStatus.FAIL);
+    }
+}

--- a/src/test/java/io/hhplus/server_construction/application/outbox/facade/OutboxFacadeTest.java
+++ b/src/test/java/io/hhplus/server_construction/application/outbox/facade/OutboxFacadeTest.java
@@ -1,0 +1,68 @@
+package io.hhplus.server_construction.application.outbox.facade;
+
+import io.hhplus.server_construction.domain.outbox.Outbox;
+import io.hhplus.server_construction.domain.outbox.service.OutboxService;
+import io.hhplus.server_construction.domain.outbox.vo.MessageType;
+import io.hhplus.server_construction.domain.outbox.vo.OutboxStatus;
+import io.hhplus.server_construction.support.kafka.KafkaConstants;
+import io.hhplus.server_construction.support.kafka.KafkaProducer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class OutboxFacadeTest {
+
+    @InjectMocks
+    OutboxFacade outboxFacade;
+
+    @Mock
+    OutboxService outboxService;
+
+    @Mock
+    KafkaProducer kafkaProducer;
+
+    @Test
+    @DisplayName("재시도 횟수가 3회 이상인 outbox 실패 처리")
+    void retriesMoreThan3() {
+        // given
+        List<Outbox> outboxList = List.of(new Outbox("test", MessageType.RESERVATION, "TEST", OutboxStatus.INIT, 4));
+        LocalDateTime now = LocalDateTime.now();
+
+        // when
+        when(outboxService.findAllByStatusTargetDatetime(OutboxStatus.INIT, now))
+                .thenReturn(outboxList);
+
+        // then
+        outboxFacade.retryOutboxMessage(now);
+        assertThat(outboxList.get(0).getStatus()).isEqualTo(OutboxStatus.FAIL);
+    }
+
+    @Test
+    @DisplayName("outbox 정상 재발행")
+    void retrySuccess() {
+        // given
+        List<Outbox> outboxList = List.of(Outbox.init(MessageType.RESERVATION, "TEST"));
+        LocalDateTime now = LocalDateTime.now();
+
+        // when
+        when(outboxService.findAllByStatusTargetDatetime(OutboxStatus.INIT, now))
+                .thenReturn(outboxList);
+
+        // then
+        outboxFacade.retryOutboxMessage(now);
+        Outbox outbox = outboxList.get(0);
+        verify(kafkaProducer).send(KafkaConstants.RESERVATION_TOPIC, outbox.getId(), outbox.getMessage());
+        verify(outboxService).save(outbox);
+    }
+}

--- a/src/test/java/io/hhplus/server_construction/interfaces/consumer/PaymentMessageConsumerTest.java
+++ b/src/test/java/io/hhplus/server_construction/interfaces/consumer/PaymentMessageConsumerTest.java
@@ -1,0 +1,55 @@
+package io.hhplus.server_construction.interfaces.consumer;
+
+import io.hhplus.server_construction.IntegratedTest;
+import io.hhplus.server_construction.domain.outbox.Outbox;
+import io.hhplus.server_construction.domain.outbox.repository.OutboxRepository;
+import io.hhplus.server_construction.domain.outbox.vo.MessageType;
+import io.hhplus.server_construction.domain.outbox.vo.OutboxStatus;
+import io.hhplus.server_construction.domain.waiting.repoisitory.WaitingRepository;
+import io.hhplus.server_construction.support.kafka.KafkaConstants;
+import io.hhplus.server_construction.support.kafka.KafkaProducer;
+import io.hhplus.server_construction.support.testcontainer.KafkaTestContainer;
+import io.hhplus.server_construction.support.util.JsonUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
+
+class PaymentMessageConsumerTest extends IntegratedTest implements KafkaTestContainer {
+
+    @Autowired
+    WaitingRepository waitingRepository;
+
+    @Autowired
+    OutboxRepository outboxRepository;
+
+    @Autowired
+    KafkaProducer kafkaProducer;
+
+    @Test
+    @DisplayName("메시지 발행후 토큰이 만료되는지 확인")
+    void consumeTest() {
+        // given
+        String token = "DUMMY_TOKEN";
+        waitingRepository.addActiveQueue(token);
+        Boolean activeToken = waitingRepository.isActiveToken(token);
+        assertThat(activeToken).isTrue();
+
+        Outbox outbox = Outbox.init(MessageType.PAYMENT, JsonUtil.objectToString(token));
+        outboxRepository.save(outbox);
+
+        kafkaProducer.send(KafkaConstants.PAYMENT_TOPIC, outbox.getId(), token);
+
+        // when
+        // then
+        await().pollDelay(2, TimeUnit.SECONDS)
+                .atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(outboxRepository.findById(outbox.getId()).getStatus()).isEqualTo(OutboxStatus.PUBLISHED));
+        Boolean result = waitingRepository.isActiveToken(token);
+        assertThat(result).isFalse();
+    }
+}

--- a/src/test/java/io/hhplus/server_construction/interfaces/consumer/ReservationMessageConsumerTest.java
+++ b/src/test/java/io/hhplus/server_construction/interfaces/consumer/ReservationMessageConsumerTest.java
@@ -1,0 +1,52 @@
+package io.hhplus.server_construction.interfaces.consumer;
+
+import io.hhplus.server_construction.IntegratedTest;
+import io.hhplus.server_construction.domain.outbox.Outbox;
+import io.hhplus.server_construction.domain.outbox.repository.OutboxRepository;
+import io.hhplus.server_construction.domain.outbox.vo.MessageType;
+import io.hhplus.server_construction.domain.outbox.vo.OutboxStatus;
+import io.hhplus.server_construction.domain.reservation.Reservation;
+import io.hhplus.server_construction.domain.reservation.vo.ReservationStatus;
+import io.hhplus.server_construction.domain.user.User;
+import io.hhplus.server_construction.support.kafka.KafkaConstants;
+import io.hhplus.server_construction.support.kafka.KafkaProducer;
+import io.hhplus.server_construction.support.testcontainer.KafkaTestContainer;
+import io.hhplus.server_construction.support.util.JsonUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
+
+class ReservationMessageConsumerTest extends IntegratedTest implements KafkaTestContainer {
+
+    @Autowired
+    OutboxRepository outboxRepository;
+
+    @Autowired
+    KafkaProducer kafkaProducer;
+
+    @Test
+    @DisplayName("consume 성공 - outbox 상태가 정상적으로 변경 됨")
+    void consumeOutboxTest() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        User user = User.create(1L, "조진우", BigDecimal.valueOf(10000L), now, now);
+        Reservation reservation = Reservation.create(1L, user, ReservationStatus.PAYMENT_WAITING, BigDecimal.ZERO);
+        Outbox outbox = Outbox.init(MessageType.RESERVATION, JsonUtil.objectToString(reservation));
+        outboxRepository.save(outbox);
+
+        kafkaProducer.send(KafkaConstants.RESERVATION_TOPIC, outbox.getId(), reservation);
+
+        // when
+        // then
+        await().pollDelay(2, TimeUnit.SECONDS)
+                .atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(outboxRepository.findById(outbox.getId()).getStatus()).isEqualTo(OutboxStatus.PUBLISHED));
+    }
+}

--- a/src/test/java/io/hhplus/server_construction/interfaces/kafka_test/KafkaTest.java
+++ b/src/test/java/io/hhplus/server_construction/interfaces/kafka_test/KafkaTest.java
@@ -1,12 +1,24 @@
 package io.hhplus.server_construction.interfaces.kafka_test;
 
 import io.hhplus.server_construction.IntegratedTest;
+import io.hhplus.server_construction.domain.outbox.Outbox;
+import io.hhplus.server_construction.domain.outbox.repository.OutboxRepository;
+import io.hhplus.server_construction.domain.outbox.vo.MessageType;
+import io.hhplus.server_construction.domain.outbox.vo.OutboxStatus;
+import io.hhplus.server_construction.domain.reservation.Reservation;
+import io.hhplus.server_construction.domain.reservation.vo.ReservationStatus;
+import io.hhplus.server_construction.domain.user.User;
+import io.hhplus.server_construction.support.kafka.KafkaConstants;
+import io.hhplus.server_construction.support.kafka.KafkaProducer;
 import io.hhplus.server_construction.support.testcontainer.KafkaTestContainer;
+import io.hhplus.server_construction.support.util.JsonUtil;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -20,6 +32,12 @@ class KafkaTest extends IntegratedTest implements KafkaTestContainer {
 
     @Autowired
     private TestProducer testProducer;
+
+    @Autowired
+    private OutboxRepository outboxRepository;
+
+    @Autowired
+    private KafkaProducer kafkaProducer;
 
     @Test
     @DisplayName("Kafka 연동 테스트")
@@ -40,5 +58,24 @@ class KafkaTest extends IntegratedTest implements KafkaTestContainer {
 
         log.debug("testConsumer.getTestPayloadList(): {}", testConsumer.getTestPayloadList());
         log.debug("consume cnt: {}", testConsumer.getTestPayloadList().size());
+    }
+
+    @Test
+    @DisplayName("consume 성공 - outbox 상태가 정상적으로 변경 됨")
+    void consumeOutboxTest() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        User user = User.create(1L, "조진우", BigDecimal.valueOf(10000L), now, now);
+        Reservation reservation = Reservation.create(1L, user, ReservationStatus.PAYMENT_WAITING, BigDecimal.ZERO);
+        Outbox outbox = Outbox.init(MessageType.RESERVATION, JsonUtil.objectToString(reservation));
+        outboxRepository.save(outbox);
+
+        kafkaProducer.send(KafkaConstants.RESERVATION_TOPIC, outbox.getId(), reservation);
+
+        // when
+        // then
+        await().pollDelay(2, TimeUnit.SECONDS)
+                .atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(outboxRepository.findById(outbox.getId()).getStatus()).isEqualTo(OutboxStatus.PUBLISHED));
     }
 }

--- a/src/test/java/io/hhplus/server_construction/interfaces/kafka_test/KafkaTest.java
+++ b/src/test/java/io/hhplus/server_construction/interfaces/kafka_test/KafkaTest.java
@@ -1,0 +1,44 @@
+package io.hhplus.server_construction.interfaces.kafka_test;
+
+import io.hhplus.server_construction.IntegratedTest;
+import io.hhplus.server_construction.support.testcontainer.KafkaTestContainer;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
+
+@Slf4j
+class KafkaTest extends IntegratedTest implements KafkaTestContainer {
+
+    @Autowired
+    private TestConsumer testConsumer;
+
+    @Autowired
+    private TestProducer testProducer;
+
+    @Test
+    @DisplayName("Kafka 연동 테스트")
+    void kafkaTest() {
+        // given
+        int cnt = 5;
+        String topic = "testTopic";
+        for (int i = 0; i < cnt; i++) {
+            testProducer.send(topic, "TEST MESSAGE! num:" + (i + 1));
+        }
+
+        // when
+        // then
+        await().pollDelay(2, TimeUnit.SECONDS)
+                .atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(testConsumer.getTestPayloadList())
+                        .hasSize(cnt));
+
+        log.debug("testConsumer.getTestPayloadList(): {}", testConsumer.getTestPayloadList());
+        log.debug("consume cnt: {}", testConsumer.getTestPayloadList().size());
+    }
+}

--- a/src/test/java/io/hhplus/server_construction/interfaces/kafka_test/KafkaTest.java
+++ b/src/test/java/io/hhplus/server_construction/interfaces/kafka_test/KafkaTest.java
@@ -1,24 +1,12 @@
 package io.hhplus.server_construction.interfaces.kafka_test;
 
 import io.hhplus.server_construction.IntegratedTest;
-import io.hhplus.server_construction.domain.outbox.Outbox;
-import io.hhplus.server_construction.domain.outbox.repository.OutboxRepository;
-import io.hhplus.server_construction.domain.outbox.vo.MessageType;
-import io.hhplus.server_construction.domain.outbox.vo.OutboxStatus;
-import io.hhplus.server_construction.domain.reservation.Reservation;
-import io.hhplus.server_construction.domain.reservation.vo.ReservationStatus;
-import io.hhplus.server_construction.domain.user.User;
-import io.hhplus.server_construction.support.kafka.KafkaConstants;
-import io.hhplus.server_construction.support.kafka.KafkaProducer;
 import io.hhplus.server_construction.support.testcontainer.KafkaTestContainer;
-import io.hhplus.server_construction.support.util.JsonUtil;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import java.math.BigDecimal;
-import java.time.LocalDateTime;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -32,12 +20,6 @@ class KafkaTest extends IntegratedTest implements KafkaTestContainer {
 
     @Autowired
     private TestProducer testProducer;
-
-    @Autowired
-    private OutboxRepository outboxRepository;
-
-    @Autowired
-    private KafkaProducer kafkaProducer;
 
     @Test
     @DisplayName("Kafka 연동 테스트")
@@ -58,24 +40,5 @@ class KafkaTest extends IntegratedTest implements KafkaTestContainer {
 
         log.debug("testConsumer.getTestPayloadList(): {}", testConsumer.getTestPayloadList());
         log.debug("consume cnt: {}", testConsumer.getTestPayloadList().size());
-    }
-
-    @Test
-    @DisplayName("consume 성공 - outbox 상태가 정상적으로 변경 됨")
-    void consumeOutboxTest() {
-        // given
-        LocalDateTime now = LocalDateTime.now();
-        User user = User.create(1L, "조진우", BigDecimal.valueOf(10000L), now, now);
-        Reservation reservation = Reservation.create(1L, user, ReservationStatus.PAYMENT_WAITING, BigDecimal.ZERO);
-        Outbox outbox = Outbox.init(MessageType.RESERVATION, JsonUtil.objectToString(reservation));
-        outboxRepository.save(outbox);
-
-        kafkaProducer.send(KafkaConstants.RESERVATION_TOPIC, outbox.getId(), reservation);
-
-        // when
-        // then
-        await().pollDelay(2, TimeUnit.SECONDS)
-                .atMost(10, TimeUnit.SECONDS)
-                .untilAsserted(() -> assertThat(outboxRepository.findById(outbox.getId()).getStatus()).isEqualTo(OutboxStatus.PUBLISHED));
     }
 }

--- a/src/test/java/io/hhplus/server_construction/interfaces/kafka_test/TestConsumer.java
+++ b/src/test/java/io/hhplus/server_construction/interfaces/kafka_test/TestConsumer.java
@@ -1,0 +1,27 @@
+package io.hhplus.server_construction.interfaces.kafka_test;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@Getter
+public class TestConsumer {
+
+    private final List<String> testPayloadList = new ArrayList<>();
+
+    @KafkaListener(topics = "testTopic", groupId = "testGroup")
+    public void consume(String payload) {
+        log.debug("payload: {}", payload);
+
+        // 테스트용 데이터 저장
+        testPayloadList.add(payload);
+    }
+}

--- a/src/test/java/io/hhplus/server_construction/interfaces/kafka_test/TestProducer.java
+++ b/src/test/java/io/hhplus/server_construction/interfaces/kafka_test/TestProducer.java
@@ -1,0 +1,19 @@
+package io.hhplus.server_construction.interfaces.kafka_test;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TestProducer {
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    public void send(String topic, String message) {
+        log.debug("send message: {}, topic: {}", message, topic);
+        kafkaTemplate.send(topic, message);
+    }
+}

--- a/src/test/java/io/hhplus/server_construction/interfaces/reservation/ReservationControllerIntegratedTest.java
+++ b/src/test/java/io/hhplus/server_construction/interfaces/reservation/ReservationControllerIntegratedTest.java
@@ -1,35 +1,15 @@
 package io.hhplus.server_construction.interfaces.reservation;
 
 import io.hhplus.server_construction.IntegratedTest;
-import io.hhplus.server_construction.application.reservation.dto.ReservationConcertResult;
-import io.hhplus.server_construction.application.reservation.facade.ReservationFacade;
-import io.hhplus.server_construction.domain.concert.Concert;
-import io.hhplus.server_construction.domain.concert.ConcertSchedule;
-import io.hhplus.server_construction.domain.concert.ConcertSeat;
-import io.hhplus.server_construction.domain.concert.vo.ConcertScheduleStatus;
-import io.hhplus.server_construction.domain.concert.vo.ConcertSeatGrade;
-import io.hhplus.server_construction.domain.concert.vo.ConcertSeatStatus;
-import io.hhplus.server_construction.domain.reservation.Reservation;
-import io.hhplus.server_construction.domain.reservation.ReservationItem;
-import io.hhplus.server_construction.domain.reservation.vo.ReservationStatus;
-import io.hhplus.server_construction.domain.user.User;
-import io.hhplus.server_construction.interfaces.controller.reservation.ReservationController;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.jdbc.Sql;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.ResultActions;
 
-import java.math.BigDecimal;
-import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -37,11 +17,6 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @Sql(scripts = {
         "classpath:/db/create_waiting.sql",
@@ -88,8 +63,13 @@ class ReservationControllerIntegratedTest extends IntegratedTest {
                     "userId": 1
                 }
                 """;
+        ExtractableResponse<Response> waitingToken = RestAssured
+                .given().log().all()
+                .when().get("/waiting/check")
+                .then().log().all().extract();
+
         Map<String, Object> headers = new HashMap<>();
-        headers.put("Authorization", "DUMMY_TOKEN_2");
+        headers.put("Authorization", waitingToken.jsonPath().getString("token"));
 
         // when
         ExtractableResponse<Response> response = RestAssured

--- a/src/test/java/io/hhplus/server_construction/support/testcontainer/KafkaTestContainer.java
+++ b/src/test/java/io/hhplus/server_construction/support/testcontainer/KafkaTestContainer.java
@@ -1,0 +1,24 @@
+package io.hhplus.server_construction.support.testcontainer;
+
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+public interface KafkaTestContainer {
+
+    String DOCKER_KAFKA_IMAGE = "confluentinc/cp-kafka:latest";
+
+    @Container
+    KafkaContainer container = new KafkaContainer(DockerImageName.parse(DOCKER_KAFKA_IMAGE));
+
+    @DynamicPropertySource
+    static void overrideProps(DynamicPropertyRegistry registry) {
+        registry.add("spring.kafka.bootstrap-servers", container::getBootstrapServers);
+        registry.add("spring.kafka.consumer.bootstrap-servers", container::getBootstrapServers);
+        registry.add("spring.kafka.producer.bootstrap-servers", container::getBootstrapServers);
+    }
+}


### PR DESCRIPTION
커밋이 조금 지저분합니다 죄송합니다.. 🙇‍♂️

## 변경 사항
- 테스트컨테이너를 이용하여 Kafka 테스트 진행
- 기존 이벤트 발행을 Kafka 메시지 발행으로 변경
- Outbox 패턴을 이용하여 발행실패 메시지 재발행 로직 구현

## 리뷰 포인트
- [kafka 연동 및 테스트](https://github.com/jo94kr/hhplus-03-server-construction/pull/45/commits/5f261ae39df14d6bbf822793e21c369652caf012)
- [outbox 패턴 적용 및 메시지 발행/소비 로직](https://github.com/jo94kr/hhplus-03-server-construction/pull/45/commits/3c962e01eda588ebff2456ca0ff0fe64b836289f)
- 테스트
  - [outbox 테스트 및 스케줄러 테스트](https://github.com/jo94kr/hhplus-03-server-construction/pull/45/commits/8d678711f965d99565bdaf257df080242a99257c)
  - [outbox 통합 테스트](https://github.com/jo94kr/hhplus-03-server-construction/pull/45/commits/a764af0d830112ceee90f624ab950e18c2c9a680)
  - [예약 통합 테스트](https://github.com/jo94kr/hhplus-03-server-construction/pull/45/commits/9fe661c31698d54773c166625aa3b0ddd10d411e)
  - [결제 통합 테스트](https://github.com/jo94kr/hhplus-03-server-construction/pull/45/commits/4ddb10933eb81529eb37d144227e35e844fe73c1)

## 테스트 결과
kafka 이벤트 발생/소비 테스트 결과 사진 첨부합니다.

- kafka가 테스트 컨테이너에 의해 실행되고 정상적으로 메시지가 발행되고 소비되는것을 확인
![image](https://github.com/user-attachments/assets/28731065-dc97-438b-a6e8-a2b3a52026e0)
![image](https://github.com/user-attachments/assets/009a244b-f4c2-4920-8720-c75a1ff4c8ed)
![image](https://github.com/user-attachments/assets/40d6d371-6bed-4bf1-b251-a75bc1100a47)


- 메시지가 발행되고 [컨슈머](https://github.com/jo94kr/hhplus-03-server-construction/pull/45/commits/8d678711f965d99565bdaf257df080242a99257c#diff-da75baa608cdee7308a0d2af06a9d4156695958a71437e877bc50fb1cf50bca1)에서 출력하는 로그가 정상적으로 노출되는 것을 확인
![image](https://github.com/user-attachments/assets/64b52bc3-b111-4a33-8e9f-0bf233f2410d)



